### PR TITLE
Add API key auth to API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ yarn start            # run the production server
 ```
 
 Both methods produce the same result; choose whichever tool you prefer.
+
+## API Authentication
+
+POST and DELETE requests to the API routes (`/api/blog` and `/api/cars`) require
+an API key. Set the expected key in the `API_KEY` environment variable and pass
+it in the `X-API-Key` header:
+
+```bash
+curl -H "X-API-Key: $API_KEY" -X POST ...
+```
+
+Requests without a valid key receive a `401 Unauthorized` response.

--- a/frontend/pages/api/blog.ts
+++ b/frontend/pages/api/blog.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 const blogDir = path.join(process.cwd(), 'frontend/data/blog');
+const API_KEY = process.env.API_KEY;
 
 function getAllPosts() {
   const files = fs.readdirSync(blogDir);
@@ -14,6 +15,12 @@ function getAllPosts() {
 }
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (['POST', 'DELETE'].includes(req.method as string)) {
+    const key = req.headers['x-api-key'];
+    if (!API_KEY || key !== API_KEY) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+  }
   if (req.method === 'GET') {
     // List all blog posts
     try {

--- a/frontend/pages/api/cars.ts
+++ b/frontend/pages/api/cars.ts
@@ -3,8 +3,15 @@ import fs from 'fs';
 import path from 'path';
 
 const carsFile = path.join(process.cwd(), 'frontend/data/cars.json');
+const API_KEY = process.env.API_KEY;
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (['POST', 'DELETE'].includes(req.method as string)) {
+    const key = req.headers['x-api-key'];
+    if (!API_KEY || key !== API_KEY) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+  }
   if (req.method === 'GET') {
     // List all cars
     try {


### PR DESCRIPTION
## Summary
- secure blog and cars API routes with a simple API key check
- reject POST/DELETE requests without a valid key
- document API key usage in README

## Testing
- `npm install` within `frontend`
- `npm run build` within `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68875b41ab288333a218581e60500709