### PR TITLE
Add SEO audit documentation

### DIFF
--- a/docs/seo-audit-2025-02-15.md
+++ b/docs/seo-audit-2025-02-15.md
@@ -1,0 +1,39 @@
+# AutoGo.pt SEO Audit — 15 Feb 2025
+
+## Overview
+This audit reviews the on-site SEO implementation in the AutoGo.pt Next.js codebase to determine how well the site is prepared for Google organic search. Findings focus on crawlability, indexability, metadata, structured data, internationalization, and analytics/compliance. References point to specific source files.
+
+## Strengths
+- **Reusable SEO component** – Most static pages use `components/Seo.tsx`, which consistently sets title, description, canonical URLs, Open Graph/Twitter tags, meta robots, and default organization JSON-LD. This provides a strong baseline for Google to extract metadata.【F:components/Seo.tsx†L1-L92】
+- **Homepage FAQ markup** – The home page injects FAQPage JSON-LD, increasing eligibility for rich results if the answers are expanded with precise content.【F:pages/index.tsx†L162-L191】
+- **Localized foundations** – Internationalization is configured for five locales in `next-i18next`, enabling locale-specific content once translations and hreflang tags are added.【F:next-i18next.config.js†L1-L11】
+- **Indexing signals** – A permissive `robots.txt` and prebuilt XML sitemap ensure Googlebot can discover key URLs and know where to find structured navigation, assuming the sitemap stays updated.【F:public/robots.txt†L1-L3】【F:public/sitemap.xml†L1-L120】
+- **Analytics consent tooling** – The main layout includes scripts to load Google Tag Manager only after consent when an environment variable is provided, helping align with Google’s Consent Mode v2 requirements.【F:components/MainLayout.tsx†L38-L120】
+
+## Issues & Recommendations
+1. **Invalid social/structured images on car detail pages**  
+   The car detail template prefixes `https://autogo.pt` to image URLs that are already absolute (from `data/cars.json`). This produces broken Open Graph, Twitter, and JSON-LD `image` values (`https://autogo.pthttps://…`), causing Google to ignore the media assets and potentially invalidating product rich results. Update these tags to respect existing absolute URLs (e.g., only prefix when the string starts with `/`).【F:data/cars.json†L1-L40】【F:pages/cars/[slug].tsx†L1680-L1758】
+
+2. **Duplicate/contradictory Google Tag Manager loading**  
+   `_document.tsx` always loads and configures GTM with measurement ID `G-0E4057P95K`, while `MainLayout` conditionally injects GTM with consent-aware defaults. Running both can trigger double pageview hits, break Consent Mode, and make the hard-coded ID impossible to change per environment. Move all GTM loading into one consent-aware implementation and delete the hard-coded script in `_document` so analytics stays compliant.【F:pages/_document.tsx†L6-L35】【F:components/MainLayout.tsx†L38-L120】
+
+3. **Stale sitemap metadata**  
+   `public/sitemap.xml` is static with future-dated `lastmod` values (2025-10-07) for every URL. Google treats obviously inaccurate timestamps as low-quality signals. Automate sitemap generation during build or update timestamps programmatically (see existing `scripts/generate-sitemap.js`) so each URL reflects the actual last modification date.【F:public/sitemap.xml†L1-L120】
+
+4. **Missing hreflang/alternate language signals**  
+   Although multiple locales are configured, pages do not output `<link rel="alternate" hreflang="…">` tags. Without them, Google may not understand language targeting and could view duplicate content as competing pages. Implement Next.js middleware or a layout-level helper to emit hreflang links for every published locale per canonical URL.【F:next-i18next.config.js†L1-L11】【F:components/Seo.tsx†L31-L45】
+
+5. **Structured data duplication risk**  
+   `getStaticProps` for car detail pages computes a sanitized `vehicleJson`, but the component renders a separate inline JSON-LD built from unsanitized client data (see Issue 1). Consolidating on the validated object from `getStaticProps` reduces divergence and ensures all structured data goes through the same cleaning pipeline.【F:pages/cars/[slug].tsx†L40-L130】【F:pages/cars/[slug].tsx†L1733-L1758】
+
+6. **Meta keywords maintenance**  
+   Several keyword lists repeat identical entries (e.g., `carros em segunda mão` in `HOME_KEYWORDS`) and include long strings that may exceed Google’s soft limits. While Google ignores the meta keywords tag, other search engines may still parse it. Periodically deduplicate and trim these lists to focus on the most strategic phrases.【F:utils/seoKeywords.ts†L1-L102】
+
+## Next Steps
+- Fix the car detail image URL handling and reuse the sanitized `vehicleJson` payload for JSON-LD to restore valid rich data.
+- Centralize GTM/GA loading in the consent-aware path and remove hard-coded measurement IDs.
+- Hook the sitemap generation script into deployment so `lastmod` values match actual publish dates.
+- Add hreflang link tags for every supported locale per canonical route.
+- Refine keyword arrays and update FAQ answers with concise, unique copy to maximize rich result eligibility.
+
+Addressing the items above will align the site more closely with Google’s organic search requirements while preserving the solid SEO foundation already in place.


### PR DESCRIPTION
## Summary
- add an SEO audit report describing the current organic search readiness and fixes to pursue

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e62bb3aa6c8333a1dd957102098ebc